### PR TITLE
remove  "std::cerr << "AudioDecoderCoreAudio::open()" << std::endl;" …

### DIFF
--- a/src/audiodecodercoreaudio.cpp
+++ b/src/audiodecodercoreaudio.cpp
@@ -54,8 +54,7 @@ AudioDecoderCoreAudio::~AudioDecoderCoreAudio() {
 }
 
 int AudioDecoderCoreAudio::open() {
-    std::cerr << "AudioDecoderCoreAudio::open()" << std::endl;
-
+    
     //Open the audio file.
     OSStatus err;
 


### PR DESCRIPTION
This output to stderr is so annoying, so I decide to remove it
