### PR TITLE
#213 - Improve COM initialization logic to not fail if already initialized

### DIFF
--- a/include/audiodecodermediafoundation.h
+++ b/include/audiodecodermediafoundation.h
@@ -52,9 +52,9 @@
 
 #include "audiodecoderbase.h"
 
-class IMFSourceReader;
-class IMFMediaType;
-class IMFMediaSource;
+struct IMFSourceReader;
+struct IMFMediaType;
+struct IMFMediaSource;
 
 #define SHORT_SAMPLE short
 
@@ -91,6 +91,7 @@ class DllExport AudioDecoderMediaFoundation : public AudioDecoderBase {
     bool m_seeking;
 	unsigned int m_iBitsPerSample;
 	SHORT_SAMPLE m_destBufferShort[8192];
+    bool m_com_preinitialized = false;
 };
 
 #endif // ifndef AUDIODECODERMEDIAFOUNDATION_H


### PR DESCRIPTION
I accidently PR'ed this against your public repo instead of my private fork. Feel free to use it if you want anyway. Essentially, I was having issues with this library using it in my application. I need to initialize COM in multithreaded mode `CoInitializeEx(NULL, COINIT_MULTITHREADED)`. This caused some issues with using this library as it would throw an error on `open`. These changes are actually taken from the PortAudio API which has some more robust logic that deals with the case the COM is already initialized. Essentially, it checks the `CoInitializeEx()` call return. If its been initialized to some other configuration, we no longer treat it as an error and we also don't uninitialize in the destructor call.